### PR TITLE
新增远控(Email My PC)插件

### DIFF
--- a/EmailMyPC.py
+++ b/EmailMyPC.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8-*-
+import sys
+import logging
+from app_utils import sendEmail
+
+reload(sys)
+sys.setdefaultencoding('utf8')
+
+WORDS = ["DIANNAO"]
+SLUG = "emailmypc"
+
+def handle(text, mic, profile, wxbot=None):
+	logger = logging.getLogger(__name__)
+	if 'email' not in profile or ('enable' in profile['email']
+								  and not profile['email']):
+		mic.say(u'请先配置好邮箱功能')
+		return
+	address = profile['email']['address']
+	password = profile['email']['password']
+	smtp_server = profile['email']['smtp_server']
+	smtp_port = profile['email']['smtp_port']
+	if SLUG not in profile or \
+		not profile[SLUG].has_key('pc_email'):
+		mic.say('远控插件配置有误，插件使用失败')
+		return
+	pc_email = profile[SLUG]['pc_email']
+	try:
+		if any(word in text for word in [u"关机", u"关电脑", u"关闭电脑"]):
+			mic.say('即将关闭电脑，请在滴一声后进行确认')
+			input = mic.activeListen(MUSIC=True)
+			if input is not None and any(word in input for word in [u"确认", u"好", u"是", u"OK"]):
+				sendEmail("#shutdown", "", "", pc_email, address, address, password, smtp_server, smtp_port)
+				mic.say('已发送关机指令')
+			else:
+				mic.say('已取消')
+		if any(word in text for word in [u"屏幕", u"截图"]):
+			sendEmail("#screen", "", "", pc_email, address, address, password, smtp_server, smtp_port)
+			mic.say('已发送截图指令，请查看您的邮箱')
+		if any(word in text for word in [u"摄像头"]):
+			sendEmail("#cam", "", "", pc_email, address, address, password, smtp_server, smtp_port)
+			mic.say('已发送拍照指令，请查看您的邮箱')
+		if any(word in text for word in [u"快捷键"]):
+			if SLUG not in profile or \
+				not profile[SLUG].has_key('button'):
+				mic.say('您还未设置快捷键')
+				return
+			button = profile[SLUG]['button']
+			mic.say('即将发送快捷键%s，请在滴一声后进行确认' % button)
+			input = mic.activeListen(MUSIC=True)
+			if input is not None and any(word in input for word in [u"确认", u"好", u"是", u"OK"]):
+				sendEmail("#button", button, "", pc_email, address, address, password, smtp_server, smtp_port)
+				mic.say('已发送快捷键')
+			else:
+				mic.say('已取消')
+		if any(word in text for word in [u"命令", u"指令"]):
+			if SLUG not in profile or \
+				not profile[SLUG].has_key('cmd'):
+				mic.say('您还未设置指令')
+				return
+			cmd = profile[SLUG]['cmd']
+			mic.say('即将发送指令%s，请在滴一声后进行确认' % cmd)
+			input = mic.activeListen(MUSIC=True)
+			if input is not None and any(word in input for word in [u"确认", u"好", u"是", u"OK"]):
+				sendEmail("#cmd", cmd, "", pc_email, address, address, password, smtp_server, smtp_port)
+				mic.say('已发送指令')
+			else:
+				mic.say('已取消')
+	except Exception, e:
+		logger.error(e)
+		mic.say('抱歉，指令发送失败')
+
+def isValid(text):
+	return any(word in text for word in [u"关机", u"关电脑", u"关闭电脑", u"屏幕", u"截图", u"摄像头", u"快捷键", u"命令", u"指令"])

--- a/WOL.py
+++ b/WOL.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8-*-
+import socket, sys
+import struct
+import logging
+
+reload(sys)
+sys.setdefaultencoding('utf8')
+
+WORDS = ["KAIJI"]
+SLUG = "wol"
+
+def Waker(ip,mac):
+	global sent
+	def to_hex_int(s):
+		return int(s.upper(), 16)
+	
+	dest = (ip, 9)
+
+	spliter = ""
+	if mac.count(":") == 5: spliter = ":"
+	if mac.count("-") == 5: spliter = "-"
+
+	parts = mac.split(spliter)
+	a1 = to_hex_int(parts[0])
+	a2 = to_hex_int(parts[1])
+	a3 = to_hex_int(parts[2])
+	a4 = to_hex_int(parts[3])
+	a5 = to_hex_int(parts[4])
+	a6 = to_hex_int(parts[5])
+	addr = [a1, a2, a3, a4, a5, a6]
+	
+	packet = chr(255) + chr(255) + chr(255) + chr(255) + chr(255) + chr(255)
+	
+	for n in range(0,16):
+		for a in addr:
+			packet = packet + chr(a)
+	
+	packet = packet + chr(0) + chr(0) + chr(0) + chr(0) + chr(0) + chr(0)
+	
+	s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+	s.setsockopt(socket.SOL_SOCKET,socket.SO_BROADCAST,1)
+	s.sendto(packet,dest)
+	
+	if len(packet) == 108:
+		sent = True
+
+def handle(text, mic, profile, wxbot=None):
+	logger = logging.getLogger(__name__)
+	if SLUG not in profile or \
+		not profile[SLUG].has_key('ip') or \
+		not profile[SLUG].has_key('mac'):
+			mic.say('WOL配置有误，插件使用失败')
+			return
+	ip = profile[SLUG]['ip']
+	mac = profile[SLUG]['mac']
+	try:
+		Waker(ip,mac)
+		if sent:
+			mic.say('启动成功')
+	except Exception, e:
+		logger.error(e)
+		mic.say('抱歉，启动失败')
+
+
+def isValid(text):
+	return any(word in text for word in [u"开机", u"启动电脑", u"开电脑"])


### PR DESCRIPTION
以邮件方式对电脑发送指令(基于[Email My PC](https://github.com/Jackeriss/Email_My_PC))，实现语音操控电脑

建议配合[WOL插件](https://github.com/dingdang-robot/dingdang-contrib/wiki/WOL)使用

电脑需事先安装并设置[Email My PC](https://jackeriss.github.io/email_my_pc)，感谢[Jackeriss](https://www.jackeriss.com/)

## 交互示例

### 1. 关机

- 用户：关闭电脑
- 叮当：即将关闭电脑，请在滴一声后进行确认
- 用户：确认
- 叮当：已发送关机指令

### 2. 屏幕截图

- 用户：截图
- 叮当：已发送截图指令，请查看您的邮箱

### 3. 回传摄像头画面

- 用户：摄像头
- 叮当：已发送拍照指令，请查看您的邮箱

### 4. 执行快捷键 

- 用户：发送快捷键
- 叮当：即将发送快捷键`内容` ，请在滴一声后进行确认
- 用户：确认
- 叮当：已发送快捷键

### 5. 执行CMD命令

- 用户：发送指令
- 叮当：即将发送指令`内容` ，请在滴一声后进行确认
- 用户：确认
- 叮当：已发送指令

## 配置

需电脑接收邮箱及自定义快捷键、指令(可选)

``` yml
# Email My PC
emailmypc:
    pc_email: '电脑接收邮箱'
    button: '自定义快捷键'
    cmd: '自定义指令'
```
