### PR TITLE
新增台灯控制插件

### DIFF
--- a/Lamp.py
+++ b/Lamp.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8-*-  # 台灯控制
+import sys
+import os
+import logging
+import wiringpi 
+
+sys.setdefaultencoding('utf8')
+
+SLUG="Lamp"
+
+WORDS=["TAIDENG"]
+
+def handle(text, mic, profile, wxbot=None):
+
+    logger = logging.getLogger(__name__)
+    # get config
+    pin=profile[SLUG]['pin']
+    wiringpi.wiringPiSetupPhys()
+    wiringpi.pinMode(pin,1)
+
+    if any(word in text for word in [u"打开",u"开启"]):
+        wiringpi.digitalWrite(pin,0)
+        mic.say("好的，已经打开台灯")
+    elif any(word in text for word in [u"关闭",u"关掉",u"熄灭"]):
+        wiringpi.digitalWrite(pin,1)
+        mic.say("好的，已经关闭台灯")
+    return True
+
+
+def isValid(text):
+    """
+        Returns True if the input is related to weather.
+        Arguments:
+        text -- user-input, typically transcribed speech
+    """
+
+    return u"台灯" in text


### PR DESCRIPTION
用于驱动 继电器，控制家用台灯 插件
## 交互示例

- 用户： 打开台灯
- 叮当：已经打开台灯

## 配置文件

Lamp:
   pin: 7             # 使用的 GPIO 口定义（这儿特制板针编号 BOARD)

