### PR TITLE
新增新闻插件（从http://www.tuling123.com/的API获取）

### DIFF
--- a/News.py
+++ b/News.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8-*-                                                                                                                                                         # 天气插件
+import sys
+import json, urllib,requests
+reload(sys)
+sys.setdefaultencoding('utf8')
+# Standard module stuff                                                                                                                                                     WORDS = []
+SLUG = "headline_news"
+WORDS = ["XINWEN"]
+API = "http://www.tuling123.com/openapi/api"
+params = {
+        "key":"7a9a22943621490cab7627e6b6a6e1e2",
+        "info":"今日新闻"
+    }
+def handle(text, mic, profile, wxbot=None):
+    if SLUG not in profile or \
+       'key' not in profile[SLUG]:
+        mic.say(u"新闻插件配置有误，插件使用失败", cache=True)
+        return
+    key = profile[SLUG]['key']
+    params = {
+        "key":key,
+        "info":"今日新闻"
+    }
+
+    mic.say("正在获取中，请稍后")
+    result = requests.get(API, params, timeout=1)
+    json_dict = json.loads(result.text)
+    news_for_tts = "转换完成，以下是今日新闻:"
+    mic.say("亲，已帮您找到相关新闻,正在转为语音")
+    for item in json_dict['list']:
+		title = item['article']
+		news_for_tts = news_for_tts + title + '，'
+    mic.say(news_for_tts)
+    mic.say('新闻播放结束', cache=True)
+    pass
+
+def isValid(text):
+    """
+        Returns True if the input is related to weather.
+        Arguments:
+        text -- user-input, typically transcribed speech
+    """
+    return u"新闻" in text


### PR DESCRIPTION
用于获取今日新闻，使用图灵机器人提供的API接口（http://www.tuling123.com/openapi/api）。因为第三方插件中的HeadlineNews插件用的是聚合数据新闻头条提供的API，而聚合数据新闻头条使用是需要实名认证的。所以我就自己编写了一款用图灵机器人API的插件，此插件可以直接使用图灵机器人网站的账号，不用重新注册。
注意：此插件可能会和HeadlineNews发生冲突，使用前需把HeadlineNews.py删除。
本插件尚处于开发阶段，最近正在完善 。现在只能获取今日新闻，我会逐步加上实时新闻、体育新闻、娱乐新闻、财经新闻等更多类别的资讯内容。

### 交互示例 ###

用户：新闻
叮当：
        “正在获取中，请稍后”——等待大约两秒
        "亲，已帮您找到相关新闻,正在转为语音"——等待大约十秒（如果开启了“当内容过长，改为发送内容）就会直接发到您的微信或邮件上。
        "转换完成，以下是今日新闻"：宝成铁路陕西段中断 未来三天这些车次停运    第80集团军政工部副主任毕可弟告别军旅 师职大校……

### 配置 ###

首先要到图灵机器人网站上将：我的机器人>技能拓展>新闻资讯设为ON

然后在/home/pi/.dingdang/profile.yml中加一段

# 今日新闻
# 图灵机器人新闻头条API
# http://www.tuling123.com
headline_news:
    key: '图灵机器人的AppKey'

再次说明：此插件可能会和HeadlineNews发生冲突，使用前需把HeadlineNews.py删除。